### PR TITLE
retry (up to twice per batch) get_historical_features when request fails on client side

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wyvern-ai"
-version = "0.0.2"
+version = "0.0.3"
 description = ""
 authors = ["Wyvern AI <info@wyvern.ai>"]
 readme = "README.md"


### PR DESCRIPTION
Sometimes feature store worker times out and the client request will fail. Adding retry should mitigate the risk of single request failure.



- [ ] Does this PR have impact on local development experience? If yes, make sure you have a plan and add the documentations to address issues that come with the change
- [ ] bump version
- [ ] make a release
- [ ] publish to pypi service
