### PR TITLE
Making feature-store calls fail-safe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wyvern-ai"
-version = "0.0.6"
+version = "0.0.7"
 description = ""
 authors = ["Wyvern AI <info@wyvern.ai>"]
 readme = "README.md"

--- a/wyvern/api.py
+++ b/wyvern/api.py
@@ -201,7 +201,7 @@ class WyvernAPI:
         self,
         response: Union[httpx.Response, requests.Response],
     ) -> None:
-        raise WyvernError(f"Request failed [{response.status_code}]: {response.json()}")
+        raise WyvernError(f"Request failed [{response.status_code}]: {response.text}")
 
     def _convert_online_features_to_df(
         self,

--- a/wyvern/components/features/feature_retrieval_pipeline.py
+++ b/wyvern/components/features/feature_retrieval_pipeline.py
@@ -50,6 +50,7 @@ class FeatureRetrievalPipeline(
         self,
         *upstreams: Component,
         name: str,
+        handle_exceptions: bool = False,
     ):
         self.real_time_features: List[
             RealtimeFeatureComponent
@@ -60,6 +61,7 @@ class FeatureRetrievalPipeline(
         self.feature_logger_component: FeatureEventLoggingComponent = (
             FeatureEventLoggingComponent()
         )
+        self.handle_exceptions = handle_exceptions
         super().__init__(
             feature_store_retrieval_component,
             self.feature_logger_component,
@@ -120,7 +122,9 @@ class FeatureRetrievalPipeline(
 
         feature_retrieval_response: FeatureMap = (
             await self.feature_retrieval_component.execute(
-                input=feature_retrieval_request, **kwargs
+                input=feature_retrieval_request,
+                handle_exceptions=self.handle_exceptions,
+                **kwargs,
             )
         )
 

--- a/wyvern/components/features/feature_store.py
+++ b/wyvern/components/features/feature_store.py
@@ -73,7 +73,9 @@ class FeatureStoreRetrievalComponent(
         )
 
         if response.status_code != 200:
-            logger.error(f"Error fetching features from feature store: {response}")
+            logger.error(
+                f"Error fetching features from feature store: [{response.status_code}] {response.json()}",
+            )
             raise WyvernFeatureStoreError(error=response.json())
 
         # TODO (suchintan): More graceful response handling here

--- a/wyvern/components/features/feature_store.py
+++ b/wyvern/components/features/feature_store.py
@@ -8,7 +8,11 @@ from pydantic import BaseModel
 from wyvern.components.component import Component
 from wyvern.config import settings
 from wyvern.core.httpx import httpx_client
-from wyvern.entities.feature_entities import FeatureData, FeatureMap
+from wyvern.entities.feature_entities import (
+    FeatureData,
+    FeatureMap,
+    build_empty_feature_map,
+)
 from wyvern.entities.identifier import Identifier
 from wyvern.exceptions import WyvernFeatureNameError, WyvernFeatureStoreError
 from wyvern.wyvern_typing import WyvernFeature
@@ -106,15 +110,25 @@ class FeatureStoreRetrievalComponent(
 
     @tracer.wrap(name="FeatureStoreRetrievalComponent.execute")
     async def execute(
-        self, input: FeatureStoreRetrievalRequest, **kwargs
+        self,
+        input: FeatureStoreRetrievalRequest,
+        handle_exceptions: bool = False,
+        **kwargs,
     ) -> FeatureMap:
         # TODO (suchintan): Integrate this with Feature Store
 
-        response = await self.fetch_features_from_feature_store(
-            input.identifiers,
-            input.feature_names,
-        )
-        return response
+        try:
+            response = await self.fetch_features_from_feature_store(
+                input.identifiers,
+                input.feature_names,
+            )
+            return response
+        except WyvernFeatureStoreError as e:
+            if handle_exceptions:
+                # logging is handled where the exception is raised
+                return build_empty_feature_map(input.identifiers, input.feature_names)
+            else:
+                raise e
 
 
 # TODO (suchintan): IS this the right way to define a singleton?

--- a/wyvern/components/pipeline_component.py
+++ b/wyvern/components/pipeline_component.py
@@ -21,7 +21,7 @@ class PipelineComponent(APIRouteComponent[REQUEST_ENTITY, RESPONSE_SCHEMA]):
         self,
         *upstreams: Component,
         name: Optional[str] = None,
-        handle_feature_store_exception: bool = False,
+        handle_feature_store_exceptions: bool = False,
     ) -> None:
         for upstream in upstreams:
             if isinstance(upstream, FeatureRetrievalPipeline):
@@ -31,7 +31,7 @@ class PipelineComponent(APIRouteComponent[REQUEST_ENTITY, RESPONSE_SCHEMA]):
 
         self.feature_retrieval_pipeline = FeatureRetrievalPipeline[REQUEST_ENTITY](
             name=f"{self.__class__.__name__}-feature_retrieval",
-            handle_exceptions=handle_feature_store_exception,
+            handle_exceptions=handle_feature_store_exceptions,
         )
         self.feature_names: Set[str] = set()
         super().__init__(*upstreams, self.feature_retrieval_pipeline, name=name)

--- a/wyvern/components/pipeline_component.py
+++ b/wyvern/components/pipeline_component.py
@@ -16,10 +16,16 @@ from wyvern.wyvern_typing import REQUEST_ENTITY, RESPONSE_SCHEMA
 
 
 class PipelineComponent(APIRouteComponent[REQUEST_ENTITY, RESPONSE_SCHEMA]):
-    def __init__(self, *upstreams: Component, name: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        *upstreams: Component,
+        name: Optional[str] = None,
+        handle_feature_store_exception: bool = False,
+    ) -> None:
         # TODO Kerem: if upstreams has the FeatureRetrievalPipeline, then the code is broken
         self.feature_retrieval_pipeline = FeatureRetrievalPipeline[REQUEST_ENTITY](
             name=f"{self.__class__.__name__}-feature_retrieval",
+            handle_exceptions=handle_feature_store_exception,
         )
         self.feature_names: Set[str] = set()
         super().__init__(*upstreams, self.feature_retrieval_pipeline, name=name)

--- a/wyvern/components/pipeline_component.py
+++ b/wyvern/components/pipeline_component.py
@@ -12,6 +12,7 @@ from wyvern.components.features.feature_retrieval_pipeline import (
 from wyvern.components.features.realtime_features_component import (
     RealtimeFeatureComponent,
 )
+from wyvern.exceptions import ComponentAlreadyDefinedInPipelineComponentError
 from wyvern.wyvern_typing import REQUEST_ENTITY, RESPONSE_SCHEMA
 
 
@@ -22,7 +23,12 @@ class PipelineComponent(APIRouteComponent[REQUEST_ENTITY, RESPONSE_SCHEMA]):
         name: Optional[str] = None,
         handle_feature_store_exception: bool = False,
     ) -> None:
-        # TODO Kerem: if upstreams has the FeatureRetrievalPipeline, then the code is broken
+        for upstream in upstreams:
+            if isinstance(upstream, FeatureRetrievalPipeline):
+                raise ComponentAlreadyDefinedInPipelineComponentError(
+                    component_type="FeatureRetrievalPipeline",
+                )
+
         self.feature_retrieval_pipeline = FeatureRetrievalPipeline[REQUEST_ENTITY](
             name=f"{self.__class__.__name__}-feature_retrieval",
             handle_exceptions=handle_feature_store_exception,

--- a/wyvern/entities/feature_entities.py
+++ b/wyvern/entities/feature_entities.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, List
 
 from pydantic.main import BaseModel
 
@@ -22,3 +22,18 @@ class FeatureData(BaseModel, frozen=True):
 
 class FeatureMap(BaseModel, frozen=True):
     feature_map: Dict[Identifier, FeatureData]
+
+
+def build_empty_feature_map(
+    identifiers: List[Identifier],
+    feature_names: List[str],
+) -> FeatureMap:
+    return FeatureMap(
+        feature_map={
+            identifier: FeatureData(
+                identifier=identifier,
+                features={feature: None for feature in feature_names},
+            )
+            for identifier in identifiers
+        },
+    )

--- a/wyvern/exceptions.py
+++ b/wyvern/exceptions.py
@@ -39,6 +39,10 @@ class WyvernRouteRegistrationError(WyvernError):
     )
 
 
+class ComponentAlreadyDefinedInPipelineComponentError(WyvernError):
+    message = "'{component_type}' is already defined by the PipelineComponent. It cannot be passed as an upstream!"
+
+
 class WyvernFeatureStoreError(WyvernError):
     message = "Received error from feature store: {error}"
 


### PR DESCRIPTION
This PR adds a parameter called `handle_exceptions` to `FeatureRetrievalPipeline` which is `False` by default.

This parameter controls if
- the feature store calls fail loudly
- the feature store failures are logged but the execution is not interrupted. All the requested features from the feature store are replaced with null values. 

- [ ] Does this PR have impact on local development experience? If yes, make sure you have a plan and add the documentations to address issues that come with the change
- [x] bump version
- [ ] make a release
- [ ] publish to pypi service
