### PR TITLE
feast request IDENTIFIER for historical feature must be strings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wyvern-ai"
-version = "0.0.8-beta2"
+version = "0.0.8"
 description = ""
 authors = ["Wyvern AI <info@wyvern.ai>"]
 readme = "README.md"

--- a/wyvern/feature_store/feature_server.py
+++ b/wyvern/feature_store/feature_server.py
@@ -379,12 +379,12 @@ def generate_wyvern_store_app(
         )
 
         for feast_response in feast_responses:
-            if len(feast_response.IDENTIFIER) != len(df.REQUEST_ID):
+            if len(feast_response.IDENTIFIER) != len(df["request"]):
                 raise HTTPException(
                     status_code=400,
                     detail=(
                         f"Length of feature store response({len(feast_response.IDENTIFIER)}) "
-                        f"and request({len(df.REQUEST_ID)}) should be the same"
+                        f"and request({len(df['request'])}) should be the same"
                     ),
                 )
             new_columns = [
@@ -399,6 +399,7 @@ def generate_wyvern_store_app(
             key.upper() for key in composite_entities.keys() if key.upper() in df
         ]
         drop_columns = composite_keys + composite_keys_uppercase + ["REQUEST_ID"]
+        drop_columns = [column for column in drop_columns if column in df]
         df.drop(columns=drop_columns, inplace=True)
         final_df = df.replace({np.nan: None})
         final_df["timestamp"] = final_df["timestamp"].astype(str)

--- a/wyvern/feature_store/historical_feature_util.py
+++ b/wyvern/feature_store/historical_feature_util.py
@@ -219,7 +219,7 @@ def build_historical_registry_feature_requests(
         request_entities: Dict[str, List[Any]]
         if len(entities) == 1:
             request_entities = {
-                "IDENTIFIER": entity_values[entities[0]],
+                "IDENTIFIER": [str(v) for v in entity_values[entities[0]]],
             }
         else:
             list1 = entity_values[entities[0]]


### PR DESCRIPTION
Two bugs:
1. 
If we pass an integer feature column to the dataframe for `get_historical_features` api nowadays, we get some weird error from feature store service:

```
WyvernError: Request failed [500]: {"error":"100038 (22018): 01ae76ec-0001-4851-0002-3e921c42985e: Numeric value '8908008035606411150218070227020217433' is not recognized"}
```

This is due to that wyvern's feature store doesn't take integers as input for the entity IDENTIFIER.

the fix is just to stringify all the IDENTIFIER


2.
```
AttributeError: 'DataFrame' object has no attribute 'REQUEST_ID'. Did you mean: 'REQUEST'?
```
fix:
we should always use df["request"] column as the a column that's always there to ensure the length of feast response is the same as the df


- [ ] Does this PR have impact on local development experience? If yes, make sure you have a plan and add the documentations to address issues that come with the change
- [ ] bump version
- [ ] make a release
- [ ] publish to pypi service
