### PR TITLE
handle missing entity column error

### DIFF
--- a/wyvern/exceptions.py
+++ b/wyvern/exceptions.py
@@ -95,3 +95,7 @@ class ExperimentationProviderNotSupportedError(WyvernError):
 
 class ExperimentationClientInitializationError(WyvernError):
     message = "Failed to initialize experimentation client for provider: {provider_name}, {error}"
+
+
+class EntityColumnMissingError(WyvernError):
+    message = "Entity column {entity} is missing in the entity data"

--- a/wyvern/feature_store/historical_feature_util.py
+++ b/wyvern/feature_store/historical_feature_util.py
@@ -13,6 +13,7 @@ from wyvern.clients.snowflake import generate_snowflake_ctx
 from wyvern.components.features.realtime_features_component import (
     RealtimeFeatureComponent,
 )
+from wyvern.exceptions import EntityColumnMissingError
 from wyvern.feature_store.constants import (
     FULL_FEATURE_NAME_SEPARATOR,
     SQL_COLUMN_SEPARATOR,
@@ -68,6 +69,15 @@ def build_historical_real_time_feature_requests(
         curr_feature_names,
     ) in features_grouped_by_entity.items():
         entity_list = entity_identifier_type.split(SQL_COLUMN_SEPARATOR)
+
+        # validate entity_list
+        for entity in entity_list:
+            if entity not in entities:
+                raise EntityColumnMissingError(entity=entity)
+
+        if len(entity_list) > 2:
+            return result_dict
+
         if len(entity_list) == 1:
             # could just get all the entity_identifiers from the entities dict right away
             result_dict[entity_identifier_type] = RequestEntityIdentifierObjects(


### PR DESCRIPTION
I was testing get historical features when a required entity is missing in my df. i got this error:
```
  File "/usr/local/lib/python3.11/site-packages/wyvern/feature_store/historical_feature_util.py", line 75, in build_historical_real_time_feature_requests
    entity_identifiers=entities[entity_identifier_type],
                       ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'order'
```

this PR should better handle this error and display more useful error message.



- [ ] Does this PR have impact on local development experience? If yes, make sure you have a plan and add the documentations to address issues that come with the change
- [ ] bump version
- [ ] make a release
- [ ] publish to pypi service
