### PR TITLE
fix the staticmeothod error in CompositeIdentifierType for python version smaller than 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wyvern-ai"
-version = "0.0.8"
+version = "0.0.9"
 description = ""
 authors = ["Wyvern AI <info@wyvern.ai>"]
 readme = "README.md"

--- a/wyvern/entities/identifier.py
+++ b/wyvern/entities/identifier.py
@@ -23,13 +23,14 @@ class SimpleIdentifierType(str, Enum):
     REQUEST = "request"
 
 
+def composite(
+    primary_identifier_type: SimpleIdentifierType,
+    secondary_identifier_type: SimpleIdentifierType,
+) -> str:
+    return f"{primary_identifier_type.value}{COMPOSITE_SEPARATOR}{secondary_identifier_type.value}"
+
+
 class CompositeIdentifierType(str, Enum):
-    @staticmethod
-    def composite(
-        primary_identifier_type: SimpleIdentifierType,
-        secondary_identifier_type: SimpleIdentifierType,
-    ) -> str:
-        return f"{primary_identifier_type.value}{COMPOSITE_SEPARATOR}{secondary_identifier_type.value}"
 
     PRODUCT_QUERY = composite(
         SimpleIdentifierType.PRODUCT,


### PR DESCRIPTION
Error we're from py3.9:

```
     32         return f"{primary_identifier_type.value}{COMPOSITE_SEPARATOR}{secondary_identifier_type.value}"
     33 
---> 34     PRODUCT_QUERY = composite(
     35         SimpleIdentifierType.PRODUCT,
     36         SimpleIdentifierType.QUERY,

TypeError: 'staticmethod' object is not callable


```


- [ ] Does this PR have impact on local development experience? If yes, make sure you have a plan and add the documentations to address issues that come with the change
- [ ] bump version
- [ ] make a release
- [ ] publish to pypi service
