### PR TITLE
remove pyproject.toml modification in `wyvern init` as we won't generate pyproject.toml any more

### DIFF
--- a/wyvern/cli/commands.py
+++ b/wyvern/cli/commands.py
@@ -134,9 +134,6 @@ def init(
             shutil.move(item_path, os.path.join(project, item))
     shutil.rmtree(extracted_dir)
 
-    # replace the project name and author in pyproject.toml
-    _replace_info(project)
-
     tracking.capture(event="oss_init_succeed")
     typer.echo(
         f"Successfully initialized Wyvern application template code in {project}",


### PR DESCRIPTION
Ppl have their own flavor of how to manage their python files. no need to create the pyproject.toml file at all.


- [ ] Does this PR have impact on local development experience? If yes, make sure you have a plan and add the documentations to address issues that come with the change
- [ ] bump version
- [ ] make a release
- [ ] publish to pypi service
