### PR TITLE
shu/more 0.0.18 fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wyvern-ai"
-version = "0.0.18-beta1"
+version = "0.0.18-beta2"
 description = ""
 authors = ["Wyvern AI <info@wyvern.ai>"]
 readme = "README.md"

--- a/wyvern/__init__.py
+++ b/wyvern/__init__.py
@@ -20,7 +20,7 @@ from wyvern.entities.identifier_entities import (
     WyvernDataModel,
     WyvernEntity,
 )
-from wyvern.entities.model_entities import ModelInput, ModelOutput
+from wyvern.entities.model_entities import ChainedModelInput, ModelInput, ModelOutput
 from wyvern.feature_store.feature_server import generate_wyvern_store_app
 from wyvern.service import WyvernService
 from wyvern.wyvern_logging import setup_logging
@@ -34,6 +34,7 @@ setup_tracing()
 __all__ = [
     "generate_wyvern_store_app",
     "CandidateSetEntity",
+    "ChainedModelInput",
     "CompositeIdentifier",
     "FeatureData",
     "FeatureMap",

--- a/wyvern/components/component.py
+++ b/wyvern/components/component.py
@@ -190,5 +190,12 @@ class Component(Generic[INPUT_TYPE, OUTPUT_TYPE]):
             Dict[str, Optional[Union[float, str, list[float]]]],
         ]
     ]:
+        """
+        Gets the model output for the given identifier
+
+        Args:
+            model_name: str. The name of the model
+            identifier: Identifier. The entity identifier
+        """
         current_request = request_context.ensure_current_request()
         return current_request.get_model_output(model_name, identifier)

--- a/wyvern/components/models/model_component.py
+++ b/wyvern/components/models/model_component.py
@@ -30,6 +30,9 @@ class ModelEventData(BaseModel):
         entity_identifier: The identifier of the entity that was used to generate the model output. This is optional.
         entity_identifier_type: The type of the identifier of the entity that was used to generate the model output.
             This is optional.
+        target: The key in the dictionary output.
+            This attribute will only appear when the output of the model is a dictionary.
+            This is optional.
     """
 
     model_name: str

--- a/wyvern/components/models/model_component.py
+++ b/wyvern/components/models/model_component.py
@@ -69,7 +69,7 @@ class ModelComponent(
         self,
         *upstreams,
         name: Optional[str] = None,
-        cache_output: bool = True,
+        cache_output: bool = False,
     ):
         super().__init__(*upstreams, name=name)
         self.model_input_type = self.get_type_args_simple(0)


### PR DESCRIPTION
- model output cache becomes False by default
- ChainedModelInput could be imported from wyvern direction: `from wyvern import ChainedModelInput`
- some docstrings


- [ ] Does this PR have impact on local development experience? If yes, make sure you have a plan and add the documentations to address issues that come with the change
- [ ] bump version
- [ ] make a release
- [ ] publish to pypi service
