### PR TITLE
shu/do not enforce features in model component

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wyvern-ai"
-version = "0.0.18-beta3"
+version = "0.0.18-beta4"
 description = ""
 authors = ["Wyvern AI <info@wyvern.ai>"]
 readme = "README.md"

--- a/wyvern/components/models/model_component.py
+++ b/wyvern/components/models/model_component.py
@@ -91,12 +91,10 @@ class ModelComponent(
 
         Our system will automatically fetch the required features from the feature store
             to make this model evaluation possible
+
+        By default, a model component does not require any features, so this function returns an empty set
         """
-        raise NotImplementedError(
-            f"{self.__class__.__name__} is a ModelComponent. "
-            "The @cached_property function `manifest_feature_names` must be "
-            "implemented to define features required for the model.",
-        )
+        return set()
 
     async def execute(self, input: MODEL_INPUT, **kwargs) -> MODEL_OUTPUT:
         """


### PR DESCRIPTION
in v0.0.18, manifest_feature_names won't be a required-to-define function anymore as now a lot more models within the ModelChain will not have to depend on a specific feature.


- [ ] Does this PR have impact on local development experience? If yes, make sure you have a plan and add the documentations to address issues that come with the change
- [ ] bump version
- [ ] make a release
- [ ] publish to pypi service
