### PR TITLE
business logic request should be able to take None modeloutput as a valid output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wyvern-ai"
-version = "0.0.18"
+version = "0.0.19"
 description = ""
 authors = ["Wyvern AI <info@wyvern.ai>"]
 readme = "README.md"

--- a/wyvern/components/business_logic/business_logic.py
+++ b/wyvern/components/business_logic/business_logic.py
@@ -112,7 +112,7 @@ class SingleEntityBusinessLogicResponse(
     """
 
     request: REQUEST_ENTITY
-    adjusted_output: MODEL_OUTPUT_DATA_TYPE
+    adjusted_output: Optional[MODEL_OUTPUT_DATA_TYPE] = None
 
 
 class BusinessLogicComponent(

--- a/wyvern/components/business_logic/business_logic.py
+++ b/wyvern/components/business_logic/business_logic.py
@@ -79,7 +79,7 @@ class SingleEntityBusinessLogicRequest(
 
     identifier: Identifier
     request: REQUEST_ENTITY
-    model_output: MODEL_OUTPUT_DATA_TYPE
+    model_output: Optional[MODEL_OUTPUT_DATA_TYPE] = None
 
 
 # TODO (suchintan): Possibly delete this now that events are gone

--- a/wyvern/components/single_entity_pipeline.py
+++ b/wyvern/components/single_entity_pipeline.py
@@ -19,7 +19,7 @@ from wyvern.wyvern_typing import REQUEST_ENTITY
 
 
 class SingleEntityPipelineResponse(GenericModel, Generic[MODEL_OUTPUT_DATA_TYPE]):
-    data: MODEL_OUTPUT_DATA_TYPE
+    data: Optional[MODEL_OUTPUT_DATA_TYPE] = None
     events: Optional[List[LoggedEvent[Any]]] = None
 
 
@@ -91,7 +91,7 @@ class SingleEntityPipeline(
     def generate_response(
         self,
         input: REQUEST_ENTITY,
-        pipeline_output: MODEL_OUTPUT_DATA_TYPE,
+        pipeline_output: Optional[MODEL_OUTPUT_DATA_TYPE],
     ) -> SingleEntityPipelineResponse[MODEL_OUTPUT_DATA_TYPE]:
         return SingleEntityPipelineResponse[MODEL_OUTPUT_DATA_TYPE](
             data=pipeline_output,


### PR DESCRIPTION
running into this error when model output is None:
```
ERROR: [2023-09-28 22:18:03,291] [wyvern.web_frameworks.fastapi] Validation error error=1 validation error for SingleEntityBusinessLogicRequest
```


- [ ] Does this PR have impact on local development experience? If yes, make sure you have a plan and add the documentations to address issues that come with the change
- [ ] bump version
- [ ] make a release
- [ ] publish to pypi service
