### PR TITLE
add kwargs as error attributes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wyvern-ai"
-version = "0.0.19"
+version = "0.0.20"
 description = ""
 authors = ["Wyvern AI <info@wyvern.ai>"]
 readme = "README.md"

--- a/wyvern/exceptions.py
+++ b/wyvern/exceptions.py
@@ -21,6 +21,7 @@ class WyvernError(Exception):
         **kwargs,
     ) -> None:
         self.error_code = error_code
+        self.kwargs = kwargs
         if message:
             self.message = message
         try:


### PR DESCRIPTION
this way, extra kwargs will be able to be accessed when a WyvernError is caught.


- [ ] Does this PR have impact on local development experience? If yes, make sure you have a plan and add the documentations to address issues that come with the change
- [ ] bump version
- [ ] make a release
- [ ] publish to pypi service
