### PR TITLE
Revert "Fix oscrypto version after OpenSSL upgrade (#84)"

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3028,20 +3028,16 @@ importlib-metadata = ">=6.0,<7.0"
 [[package]]
 name = "oscrypto"
 version = "1.3.0"
-description = ""
+description = "TLS (SSL) sockets, key generation, encryption, decryption, signing, verification and KDFs using the OS crypto libraries. Does not require a compiler, and relies on the OS for patching. Works on Windows, OS X and Linux/BSD."
 optional = false
 python-versions = "*"
-files = []
-develop = false
+files = [
+    {file = "oscrypto-1.3.0-py2.py3-none-any.whl", hash = "sha256:2b2f1d2d42ec152ca90ccb5682f3e051fb55986e1b170ebde472b133713e7085"},
+    {file = "oscrypto-1.3.0.tar.gz", hash = "sha256:6f5fef59cb5b3708321db7cca56aed8ad7e662853351e7991fcf60ec606d47a4"},
+]
 
 [package.dependencies]
 asn1crypto = ">=1.5.1"
-
-[package.source]
-type = "git"
-url = "https://github.com/wbond/oscrypto.git"
-reference = "d5f3437ed24257895ae1edd9e503cfb352e635a8"
-resolved_reference = "d5f3437ed24257895ae1edd9e503cfb352e635a8"
 
 [[package]]
 name = "packaging"
@@ -5329,4 +5325,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "e990796edf65f0362ac65d2302afcce3ee1de0c163751451252b11274a3c7be5"
+content-hash = "5be697802a6d07b5e8b227ef9274b46358c16e1835731bfebe3b5c66cc8d167f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wyvern-ai"
-version = "0.0.28"
+version = "0.0.27"
 description = ""
 authors = ["Wyvern AI <info@wyvern.ai>"]
 readme = "README.md"
@@ -34,7 +34,6 @@ requests = "^2.31.0"
 platformdirs = "^3.8"
 posthog = "^3.0.2"
 polars = "^0.19.6"
-oscrypto = {git = "https://github.com/wbond/oscrypto.git", rev = "d5f3437ed24257895ae1edd9e503cfb352e635a8"}
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This reverts commit 05701b85d2c5520bf2c3c67be1a11e1126e76721.

- [ ] Does this PR have impact on local development experience? If yes, make sure you have a plan and add the documentations to address issues that come with the change
- [ ] bump version
- [ ] make a release
- [ ] publish to pypi service
