### PR TITLE
always log events even if there's exception raised

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wyvern-ai"
-version = "0.0.28"
+version = "0.0.29"
 description = ""
 authors = ["Wyvern AI <info@wyvern.ai>"]
 readme = "README.md"

--- a/wyvern/web_frameworks/fastapi.py
+++ b/wyvern/web_frameworks/fastapi.py
@@ -163,13 +163,6 @@ class WyvernFastapi:
                     wyvern_req.execute_shadow_requests,
                 )
 
-                background_tasks.add_task(
-                    wyvern_kinesis_firehose.put_record_batch_callable,
-                    KinesisFirehoseStream.EVENT_STREAM,
-                    # TODO (suchintan): "invariant" list error
-                    event_logger.get_logged_events_generator(),  # type: ignore
-                )
-
                 # profiler.stop()
                 # profiler.print(show_all=True)
             except ValidationError as e:
@@ -188,6 +181,11 @@ class WyvernFastapi:
                 logger.exception(f"Unexpected error error={e} request_payload={json}")
                 raise HTTPException(status_code=500, detail=str(e))
             finally:
+                background_tasks.add_task(
+                    wyvern_kinesis_firehose.put_record_batch_callable,
+                    KinesisFirehoseStream.EVENT_STREAM,
+                    event_logger.get_logged_events_generator(),  # type: ignore
+                )
                 request_context.reset()
             if not output:
                 raise HTTPException(status_code=500, detail="something is wrong")

--- a/wyvern/web_frameworks/fastapi.py
+++ b/wyvern/web_frameworks/fastapi.py
@@ -181,6 +181,7 @@ class WyvernFastapi:
                 logger.exception(f"Unexpected error error={e} request_payload={json}")
                 raise HTTPException(status_code=500, detail=str(e))
             finally:
+                # log events no matter exception or not
                 background_tasks.add_task(
                     wyvern_kinesis_firehose.put_record_batch_callable,
                     KinesisFirehoseStream.EVENT_STREAM,


### PR DESCRIPTION
problem:
current event logger won't log anything that errored out.

solution:
the event logger should be triggered no matter exception happens or not.




- [ ] Does this PR have impact on local development experience? If yes, make sure you have a plan and add the documentations to address issues that come with the change
- [ ] bump version
- [ ] make a release
- [ ] publish to pypi service
